### PR TITLE
Add js prefix to elements where custom js is applied to

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -15,13 +15,13 @@
       </div>
 		</header>
 		<div class="container flex-grow-1 flex-shrink-0">
-      <div id="alertBrowser" class="alert alert-danger d-none" role="alert">
+      <div class="js-alert-browser alert alert-danger d-none" role="alert">
         <p class="text-center">
           Your browser is not up to date, please update your browser or try another one.
           You can check this website to find a better one: <a href="https://browsehappy.com/">https://browsehappy.com</a>
         </p>
       </div>
-      <form>
+      <form class="js-form-customize">
         <div class="mt-3">
           <h2 class="h4 my-3">
             JavaScript Plugins
@@ -71,7 +71,7 @@
           <div class="row mt-3">
             <div class="col-3">
               <div class="custom-control custom-checkbox">
-                <input class="custom-control-input require-popper js-checkbox" type="checkbox" id="chkDropdown" name="dropdown">
+                <input class="custom-control-input js-require-popper js-checkbox" type="checkbox" id="chkDropdown" name="dropdown">
                 <label class="custom-control-label" for="chkDropdown">
                   Dropdown
                 </label>
@@ -89,7 +89,7 @@
 
             <div class="col-3">
               <div class="custom-control custom-checkbox">
-                <input class="custom-control-input require-popper js-checkbox" type="checkbox" id="chkPopover" name="popover">
+                <input class="custom-control-input js-require-popper js-checkbox" type="checkbox" id="chkPopover" name="popover">
                 <label class="custom-control-label" for="chkPopover">
                   Popover
                 </label>
@@ -117,7 +117,7 @@
 
             <div class="col-3">
               <div class="custom-control custom-checkbox">
-                <input class="custom-control-input require-popper js-checkbox" type="checkbox" id="chkTooltip" name="tooltip">
+                <input class="custom-control-input js-require-popper js-checkbox" type="checkbox" id="chkTooltip" name="tooltip">
                 <label class="custom-control-label" for="chkTooltip">
                   Tooltip
                 </label>
@@ -472,25 +472,25 @@
           <div class="row">
             <div class="col-3">
               <div class="custom-control custom-checkbox">
-                <input id="checkboxPopper" class="custom-control-input" type="checkbox">
+                <input id="checkboxPopper" class="custom-control-input js-check-popper" type="checkbox">
                 <label class="custom-control-label" for="checkboxPopper">
                   Include Popper.js
                 </label>
               </div>
             </div>
-  
+
             <div class="col-3">
               <div class="custom-control custom-checkbox">
-                <input id="chkMinify" class="custom-control-input" type="checkbox" checked>
+                <input id="chkMinify" class="custom-control-input js-check-minify" type="checkbox" checked>
                 <label class="custom-control-label" for="chkMinify">
                   Minify
                 </label>
               </div>
             </div>
-  
+
             <div class="col-3">
               <div class="custom-control custom-checkbox">
-                <input id="chkCSS" class="custom-control-input" type="checkbox">
+                <input id="chkCSS" class="custom-control-input js-check-css" type="checkbox">
                 <label class="custom-control-label" for="chkCSS">
                   Include JavaScript plugin CSS
                 </label>
@@ -499,7 +499,7 @@
           </div>
         </div>
         <div class="mt-5">
-          <button id="btnSubmit" type="submit" class="btn btn-outline-primary btn-block btn-lg mt-3">
+          <button type="submit" class="btn btn-outline-primary btn-block btn-lg mt-3 js-btn-customize">
             <span class="bx bx-cog" aria-hidden="true"></span> Build
           </button>
         </div>

--- a/src/js/dialog-loader.js
+++ b/src/js/dialog-loader.js
@@ -8,22 +8,22 @@ let $generatedLink
 let $loadingStatus
 let $modalHeader
 
-const dialogClass = 'dialog-loader'
+const dialogClass = 'js-dialog-loader'
 const template = `
 <div class="modal fade ${dialogClass}" tabindex="-1" role="dialog" data-backdrop="static">
   <div class="modal-dialog modal-dialog-centered modal-sm" role="document">
     <div class="modal-content">
-      <div class="modal-header d-none">
+      <div class="modal-header d-none js-modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body text-center">
-        <div id="loader">
+        <div class="js-loader">
           <span class="bx bx-loader bx-spin bx-lg"></span>
         </div>
-        <p id="loadingStatus" class="mt-3 mb-0"></p>
-        <a id="generatedLink" class="btn btn-primary d-none">
+        <p class="js-loading-status mt-3 mb-0"></p>
+        <a class="js-generated-link btn btn-primary d-none">
           <span class="bx bx-download" aria-hidden="true"></span> Download
         </a>
       </div>
@@ -35,10 +35,10 @@ const template = `
 const createModal = () => {
   $(document.body).append(template)
   $modal = $(`.${dialogClass}`)
-  $loader = $('#loader')
-  $generatedLink = $('#generatedLink')
-  $loadingStatus = $('#loadingStatus')
-  $modalHeader = $modal.find('.modal-header')
+  $loader = $('.js-loader')
+  $generatedLink = $('.js-generated-link')
+  $loadingStatus = $('.js-loading-status')
+  $modalHeader = $modal.find('.js-modal-header')
 
   $modal.on('hidden.bs.modal', () => {
     $loadingStatus.text('')

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -17,19 +17,19 @@ let chooseToImportPopper = true
 
 $(() => {
   if (!supportedBrowser()) {
-    $('#alertBrowser').removeClass('d-none')
+    $('.js-alert-browser').removeClass('d-none')
     return
   }
 
   Sass.setWorkerUrl(getSassWorkerPath())
   createModal()
 
-  const $form = $('form')
-  const $checkBoxRequirePopper = $(document.querySelectorAll('.require-popper'))
-  const $checkboxPopper = $('#checkboxPopper')
-  const $chkMinify = $('#chkMinify')
-  const $chkCSS = $('#chkCSS')
-  const popperCheckboxList = [].slice.call(document.querySelectorAll('.require-popper'))
+  const $form = $('.js-form-customize')
+  const $checkBoxRequirePopper = $form.find('.js-require-popper')
+  const $checkboxPopper = $form.find('.js-check-popper')
+  const $chkMinify = $form.find('.js-check-minify')
+  const $chkCSS = $form.find('.js-check-css')
+  const popperCheckboxList = [].slice.call(document.querySelectorAll('.js-require-popper'))
 
   $checkboxPopper.on('click', function () {
     chooseToImportPopper = this.checked


### PR DESCRIPTION
Use classes with `.js-` prefix for elements where custom javascript is applied to.


Closes #40.