### PR TITLE
Make sure events are triggered when checkbox states are toggled

### DIFF
--- a/src/js/toggler.js
+++ b/src/js/toggler.js
@@ -28,9 +28,17 @@ $(() => {
     const checkedList = list.filter(chkBox => chkBox.checked)
 
     if (checkedList.length > 0) {
-      list.forEach(chkBox => { chkBox.checked = false })
+      list.forEach(chkBox => {
+        if (chkBox.checked) {
+          chkBox.click()
+        }
+      })
     } else {
-      list.forEach(chkBox => { chkBox.checked = true })
+      list.forEach(chkBox => {
+        if (!chkBox.checked) {
+          chkBox.click()
+        }
+      })
     }
   })
 })

--- a/src/js/toggler.js
+++ b/src/js/toggler.js
@@ -28,16 +28,14 @@ $(() => {
     const checkedList = list.filter(chkBox => chkBox.checked)
 
     if (checkedList.length > 0) {
-      list.forEach(chkBox => {
-        if (chkBox.checked) {
-          chkBox.click()
-        }
+      // Uncheck all checked checkboxes
+      checkedList.forEach(chkBox => {
+        $(chkBox).trigger('click')
       })
     } else {
+      // Check all checkboxes
       list.forEach(chkBox => {
-        if (!chkBox.checked) {
-          chkBox.click()
-        }
+        chkBox.click()
       })
     }
   })


### PR DESCRIPTION
When the toggle buttons are clicked, the checkbox events are not triggered. This prevents the popper.js checkbox to be checked when needed. PR fixes this.

Ref: https://stackoverflow.com/a/33433357/796035